### PR TITLE
Update Module Reference, Bump Go Version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
 
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.23
 
     - name: Build
       run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 _tool/
+
+# Ignore the binary generated from go build
+meek-stv

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/blackgreen100/meek-stv
+module github.com/linuxfoundation-it/meek-stv
 
-go 1.19
+go 1.23
 
 require github.com/stretchr/testify v1.8.1
 

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/blackgreen100/meek-stv/election"
-	"github.com/blackgreen100/meek-stv/meekstv"
+	"github.com/linuxfoundation-it/meek-stv/election"
+	"github.com/linuxfoundation-it/meek-stv/meekstv"
 )
 
 func main() {

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -3,7 +3,7 @@ package meekstv
 import (
 	"math"
 
-	"github.com/blackgreen100/meek-stv/election"
+	"github.com/linuxfoundation-it/meek-stv/election"
 )
 
 func Count(params *election.Election) Log {

--- a/meekstv/meekstv_test.go
+++ b/meekstv/meekstv_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/blackgreen100/meek-stv/election"
+	"github.com/linuxfoundation-it/meek-stv/election"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Bumps the golang version to 1.23, updates CI to use the default 'main'
branch, and update golang references to use the module name for the
repository.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated continuous integration settings to trigger on the new primary branch and upgraded the Go runtime to version 1.23.
	- Revised project module references and import paths to reflect a change in organizational affiliation.
	- Enhanced build configuration by expanding the set of ignored artifacts for improved version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->