### PR TITLE
Add module

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -45,7 +45,7 @@ func Count(params *election.Election) Log {
 		elected := cs.countState(Elected)
 		if elected >= params.Seats || elected+hopeful <= params.Seats {
 			round.complete(params.Seats)
-			// ITX: make sure to log the last round snapshot before returning
+			// Make sure to log the last round snapshot before returning
 			// Found edge case where the last round was not being logged when a hopeful candidate was elected
 			roundLog := round.report.last()
 			roundLog.CandidateSnapshot = round.snapshot()

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -45,6 +45,10 @@ func Count(params *election.Election) Log {
 		elected := cs.countState(Elected)
 		if elected >= params.Seats || elected+hopeful <= params.Seats {
 			round.complete(params.Seats)
+			// ITX: make sure to log the last round snapshot before returning
+			// Found edge case where the last round was not being logged when a hopeful candidate was elected
+			roundLog := round.report.last()
+			roundLog.CandidateSnapshot = round.snapshot()
 			return round.report
 		}
 		round.report.add(round.n)


### PR DESCRIPTION
This pull request includes an important change to the `Count` function in the `meekstv/meekstv.go` file. The change ensures that the last round snapshot is logged before returning, addressing an edge case where the last round was not being logged when a hopeful candidate was elected.

* [`meekstv/meekstv.go`](diffhunk://#diff-6219e52202ac67608dd7980ec528bc9ad991e36cd623d5409b718d636c2c2bc8R48-R51): Added code to log the last round snapshot before returning to ensure accurate logging of the final round when a hopeful candidate is elected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced result reporting by ensuring complete candidate data is captured for every round. This update addresses an edge case where some outcome details were previously omitted, providing users with a more comprehensive view of each round's results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->