### PR TITLE
[PCC-420] track vote transfers

### DIFF
--- a/cmd/customcase/README.md
+++ b/cmd/customcase/README.md
@@ -1,0 +1,61 @@
+# Custom Case Runner
+
+A small, focused runner to reproduce and debug specific elections with custom ballots. Useful for verifying transfer attribution, exhausted deltas, and round-by-round outcomes when integrating with an external voting service.
+
+## What it does
+
+- Builds an in-memory `Election` with your candidates and ballots
+- Runs the Meek STV count (`meekstv.Count`)
+- Prints round-by-round summaries including:
+  - Threshold (absolute and percent)
+  - Exhausted votes
+  - Candidate keep factors and votes
+  - Surplus transfers and elimination transfers (per-recipient and exhausted deltas)
+  - Elected and eliminated candidates per round
+
+## Run
+
+```bash
+# from repo root
+go run ./cmd/customcase
+```
+
+## Plugging in ballots from your voting service
+
+You can modify `cmd/customcase/main.go` to fetch or inject ballots at runtime. Two simple approaches:
+
+1) Hardcode for quick repro (current pattern)
+- Set `choices` to your choice IDs in the exact order that defines candidate indices (0..n-1)
+- Convert your ballots to zero-based candidate indices and append to the in-memory `Election`
+
+2) Environment or JSON input
+- Read `choices` and `ballots` via env vars or a JSON file
+- Map your choice IDs to indices using the `choices` array
+- Ensure ballots use zero-based indices and weights as integers
+
+Example JSON shape to parse:
+```json
+{
+  "choices": ["choice-id-0", "choice-id-1", "choice-id-2"],
+  "seats": 2,
+  "ballots": [
+    {"weight": 1, "preferences": [2,0,1]}, // means choice-id-2 (rank 1), choice-id-0 (rank 2), choice-id-1 (rank 3)
+    {"weight": 1, "preferences": [0,2,1]} // means choice-id-0 (rank 1) ..
+  ]
+}
+```
+
+## Mapping rules (critical)
+
+- Candidate indices are positional: the order of `choices` defines Index 0..n-1
+- Each ballot `preferences` array must contain these zero-based indices
+- If you use choice IDs elsewhere, always resolve by Index to prevent attribution mix-ups
+
+## Interpreting the output
+
+- Surplus transfers: Effects of an election from the previous round. Shows per-recipient gains
+- Elimination transfers: Effects of an elimination from the previous round. Shows per-recipient gains 
+
+## Tips
+
+- Use this runner to iterate quickly on corner cases without changing the main program 

--- a/cmd/customcase/main.go
+++ b/cmd/customcase/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/linuxfoundation-it/meek-stv/election"
+	"github.com/linuxfoundation-it/meek-stv/meekstv"
+)
+
+func nameByIndex(snapshot []meekstv.Candidate, idx int) string {
+	for i := range snapshot {
+		if snapshot[i].Index == idx {
+			return snapshot[i].Name
+		}
+	}
+	return fmt.Sprintf("candidate#%d", idx)
+}
+
+func main() {
+	choices := []string{
+		"1e6ce7e3-e957-4749-8679-8b2a86751da1", // idx 0
+		"2faad174-ea38-47e0-aa47-e0b4b3e146bb", // idx 1
+		"468db457-cdee-483c-8182-ad260547524b", // idx 2
+		"69399f1d-ee87-496f-ac73-4990af6f91b7", // idx 3
+		"6a90af0c-e2bd-48b6-882a-445122e46532", // idx 4
+		"7d72a470-19f5-4bea-9c47-6de52b18bf8f", // idx 5
+	}
+
+	params := &election.Election{
+		Title:          "Custom",
+		Candidates:     len(choices),
+		Seats:          2,
+		Withdrawn:      map[int]bool{},
+		Ballots:        []election.Ballot{},
+		CandidateNames: choices,
+	}
+
+	add := func(weight int, prefs []int) {
+		params.Ballots = append(params.Ballots, election.Ballot{Weight: weight, Preferences: prefs})
+	}
+
+	add(1, []int{5, 2, 4, 0, 1, 3})
+	add(1, []int{0, 5, 2, 4, 3, 1})
+	add(1, []int{1, 3, 5, 0, 2, 4})
+	add(1, []int{0, 4, 1, 3, 5, 2})
+	add(1, []int{2, 4, 1, 5, 3, 0})
+	add(1, []int{1, 2, 5, 4, 0, 3})
+	add(1, []int{1, 2, 5, 0, 3, 4})
+	add(1, []int{1, 2, 4, 5, 0, 3})
+	add(1, []int{2, 4, 3, 1, 5, 0})
+
+	report := meekstv.Count(params)
+
+	for i := 0; i < report.NumRounds(); i++ {
+		e := report.Round(i)
+		fmt.Printf("Round %d:\n", e.Round)
+		fmt.Printf("Threshold: %.2f (%.2f%%)\n", e.Threshold, e.Threshold/e.TotVotes*100)
+		fmt.Printf("Exhausted: %.2f\n", e.Exhausted)
+		fmt.Println("candidate\tkeep\tvotes")
+		for _, c := range e.CandidateSnapshot {
+			fmt.Printf("%s\t%.2f\t%.2f\n", c.Name, c.KeepFactor, c.Votes)
+		}
+		if len(e.SurplusReceived) > 0 {
+			fmt.Println("surplus transfers:")
+			for idx, amt := range e.SurplusReceived {
+				fmt.Printf("  -> %s: %.2f\n", nameByIndex(e.CandidateSnapshot, idx), amt)
+			}
+			if e.SurplusExhaustedDelta > 0 {
+				fmt.Printf("  -> exhausted: %.2f\n", e.SurplusExhaustedDelta)
+			}
+		}
+		if len(e.EliminationReceived) > 0 {
+			fmt.Println("elimination transfers:")
+			for idx, amt := range e.EliminationReceived {
+				fmt.Printf("  -> %s: %.2f\n", nameByIndex(e.CandidateSnapshot, idx), amt)
+			}
+			if e.EliminationExhaustedDelta > 0 {
+				fmt.Printf("  -> exhausted: %.2f\n", e.EliminationExhaustedDelta)
+			}
+		}
+		for _, elected := range e.Elected {
+			fmt.Printf("Elected: %s with %.2f votes\n", elected.Name, elected.Votes)
+		}
+		for _, defeated := range e.Defeated {
+			fmt.Printf("Eliminated: %s\n", defeated.Name)
+		}
+		fmt.Println("-------------------------")
+	}
+}

--- a/cmd/customcase/main.go
+++ b/cmd/customcase/main.go
@@ -7,6 +7,9 @@ import (
 	"github.com/linuxfoundation-it/meek-stv/meekstv"
 )
 
+// nameByIndex resolves a candidate's display name (or choice ID) from its stable
+// Candidate.Index. Always resolve by Index (not by slice position) to avoid
+// attribution mix-ups when snapshots reorder.
 func nameByIndex(snapshot []meekstv.Candidate, idx int) string {
 	for i := range snapshot {
 		if snapshot[i].Index == idx {
@@ -17,6 +20,8 @@ func nameByIndex(snapshot []meekstv.Candidate, idx int) string {
 }
 
 func main() {
+	// The order of choices defines stable Candidate.Index values 0..n-1.
+	// All ballots must use these zero-based indices in their preferences.
 	choices := []string{
 		"1e6ce7e3-e957-4749-8679-8b2a86751da1", // idx 0
 		"2faad174-ea38-47e0-aa47-e0b4b3e146bb", // idx 1
@@ -36,9 +41,11 @@ func main() {
 	}
 
 	add := func(weight int, prefs []int) {
+		// prefs must be zero-based indices into the choices slice above.
 		params.Ballots = append(params.Ballots, election.Ballot{Weight: weight, Preferences: prefs})
 	}
 
+	// Example ballots: each line is weight 1 and a ranked list of candidate indices.
 	add(1, []int{5, 2, 4, 0, 1, 3})
 	add(1, []int{0, 5, 2, 4, 3, 1})
 	add(1, []int{1, 3, 5, 0, 2, 4})
@@ -60,22 +67,24 @@ func main() {
 		for _, c := range e.CandidateSnapshot {
 			fmt.Printf("%s\t%.2f\t%.2f\n", c.Name, c.KeepFactor, c.Votes)
 		}
+		// NOTE on transfers:
+		// - The transfers listed in a given round are the EFFECTS of the previous round's event.
+		//   * surplus transfers: previous round elected one or more candidates; their keep factors
+		//     were reduced and the surplus flowed to next preferences when re-walking ballots.
+		//   * elimination transfers: previous round eliminated a candidate; their would-be share
+		//     is passed to each ballot's next available preference when re-walking ballots.
+		// - Amounts are computed as per-candidate vote deltas between consecutive snapshots and
+		//   are keyed by Candidate.Index to ensure correct attribution.
 		if len(e.SurplusReceived) > 0 {
 			fmt.Println("surplus transfers:")
 			for idx, amt := range e.SurplusReceived {
 				fmt.Printf("  -> %s: %.2f\n", nameByIndex(e.CandidateSnapshot, idx), amt)
-			}
-			if e.SurplusExhaustedDelta > 0 {
-				fmt.Printf("  -> exhausted: %.2f\n", e.SurplusExhaustedDelta)
 			}
 		}
 		if len(e.EliminationReceived) > 0 {
 			fmt.Println("elimination transfers:")
 			for idx, amt := range e.EliminationReceived {
 				fmt.Printf("  -> %s: %.2f\n", nameByIndex(e.CandidateSnapshot, idx), amt)
-			}
-			if e.EliminationExhaustedDelta > 0 {
-				fmt.Printf("  -> exhausted: %.2f\n", e.EliminationExhaustedDelta)
 			}
 		}
 		for _, elected := range e.Elected {

--- a/meekstv/custom_case_test.go
+++ b/meekstv/custom_case_test.go
@@ -1,0 +1,65 @@
+package meekstv
+
+import (
+	"testing"
+
+	"github.com/linuxfoundation-it/meek-stv/election"
+)
+
+func TestCustomCase_EliminationRecipients(t *testing.T) {
+	// choices order defines indices 0..5 matching the provided IDs
+	choices := []string{
+		"1e6ce7e3-e957-4749-8679-8b2a86751da1", // idx 0
+		"2faad174-ea38-47e0-aa47-e0b4b3e146bb", // idx 1
+		"468db457-cdee-483c-8182-ad260547524b", // idx 2
+		"69399f1d-ee87-496f-ac73-4990af6f91b7", // idx 3
+		"6a90af0c-e2bd-48b6-882a-445122e46532", // idx 4
+		"7d72a470-19f5-4bea-9c47-6de52b18bf8f", // idx 5
+	}
+
+	params := &election.Election{
+		Title:          "Custom",
+		Candidates:     len(choices),
+		Seats:          2,
+		Withdrawn:      map[int]bool{},
+		Ballots:        []election.Ballot{},
+		CandidateNames: choices,
+	}
+
+	add := func(weight int, prefs []int) {
+		params.Ballots = append(params.Ballots, election.Ballot{Weight: weight, Preferences: prefs})
+	}
+
+	// 9 ballots, weight 1 each, zero-based indices as provided
+	add(1, []int{5, 2, 4, 0, 1, 3})
+	add(1, []int{0, 5, 2, 4, 3, 1})
+	add(1, []int{1, 3, 5, 0, 2, 4})
+	add(1, []int{0, 4, 1, 3, 5, 2})
+	add(1, []int{2, 4, 1, 5, 3, 0})
+	add(1, []int{1, 2, 5, 4, 0, 3})
+	add(1, []int{1, 2, 5, 0, 3, 4})
+	add(1, []int{1, 2, 4, 5, 0, 3})
+	add(1, []int{2, 4, 3, 1, 5, 0})
+
+	report := Count(params)
+
+	entries := report.entries
+	// Find the round where the previous round eliminated idx 5 (7d72...)
+	found := false
+	for i := 1; i < len(entries); i++ {
+		prev := entries[i-1]
+		if len(prev.Defeated) > 0 && prev.Defeated[0].Index == 5 {
+			cur := entries[i]
+			gotTo468 := cur.EliminationReceived[2]
+			gotTo1e6 := cur.EliminationReceived[0]
+			if gotTo468 != 1.0 || gotTo1e6 != 0.25 {
+				t.Fatalf("unexpected elimination recipients: to 468d=%.2f, to 1e6c=%.2f; want 1.00 and 0.25", gotTo468, gotTo1e6)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("did not find a round after eliminating idx 5 (7d72...)")
+	}
+}

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -141,6 +141,9 @@ func (round *meekStvRound) run(input *election.Election) {
 		totSurplus += c.Surplus
 	}
 
+	// Calculate transferred surplus votes
+	roundLog.TransferredSurplus = totSurplus
+
 	// Test for iteration finished. If step B.2.c elected a candidate, continue at B.1.
 	if newlyElected {
 		round.prevSurplus = totSurplus
@@ -163,6 +166,10 @@ func (round *meekStvRound) run(input *election.Election) {
 			d = c
 		}
 	}
+
+	// Log the votes of the eliminated candidate
+	roundLog.TransferredFromElimination = d.Votes
+
 	d.State = Defeated
 	d.KeepFactor = 0.0
 

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -38,6 +38,16 @@ func (l *Log) Print() {
 	for _, e := range l.entries {
 		fmt.Println("round", e.Round)
 		fmt.Printf("threshold %.02f (%.02f)\n", e.Threshold, e.Threshold/e.TotVotes*100)
+		fmt.Printf("transferred surplus: %.02f\n", e.TransferredSurplus)
+		fmt.Printf("transferred from elimination: %.02f\n", e.TransferredFromElimination)
+		fmt.Printf("exhausted: %.02f\n", e.Exhausted)
+
+		// print the candidate votes in a table containing the name, keep factor, votes, and state
+		// for every round
+		fmt.Println("candidate\tkeep\tvotes")
+		for _, c := range e.CandidateSnapshot {
+			fmt.Printf("%s\t%.02f\t%.02f\n", c.Name, c.KeepFactor, c.Votes)
+		}
 
 		for _, elected := range e.Elected {
 			fmt.Printf("elected %s with %.02f votes\n", elected.Name, elected.Votes)
@@ -55,6 +65,15 @@ func (l *Log) PrintString() string {
 	for _, e := range l.entries {
 		result.WriteString(fmt.Sprintf("Round %d:\n", e.Round))
 		result.WriteString(fmt.Sprintf("Threshold: %.02f (%.02f%%)\n", e.Threshold, e.Threshold/e.TotVotes*100))
+		result.WriteString(fmt.Sprintf("Transferred surplus: %.02f\n", e.TransferredSurplus))
+		result.WriteString(fmt.Sprintf("Transferred from elimination: %.02f\n", e.TransferredFromElimination))
+		result.WriteString(fmt.Sprintf("Exhausted: %.02f\n", e.Exhausted))
+
+		// print the candidate votes in a table containing the name, keep factor, votes, and state
+		result.WriteString("candidate\tkeep\tvotes\n")
+		for _, c := range e.CandidateSnapshot {
+			result.WriteString(fmt.Sprintf("%s\t%.02f\t%.02f\n", c.Name, c.KeepFactor, c.Votes))
+		}
 
 		for _, elected := range e.Elected {
 			result.WriteString(fmt.Sprintf("Elected: %s with %.02f votes\n", elected.Name, elected.Votes))
@@ -77,13 +96,16 @@ func (l *Log) last() *LogEntry {
 }
 
 type LogEntry struct {
-	Round             int
-	Threshold         float64
-	TotVotes          float64
-	CandidateSnapshot []Candidate
-	Elected           []Candidate
-	Defeated          []Candidate
-	Exhausted         float64
+	Round                      int
+	Threshold                  float64
+	TotVotes                   float64
+	CandidateSnapshot          []Candidate
+	Elected                    []Candidate
+	Defeated                   []Candidate
+	Exhausted                  float64
+	TransferredSurplus         float64         // votes transferred from surplus
+	TransferredFromElimination float64         // votes transferred from eliminated candidates
+	TransferredVotes           map[int]float64 // votes transferred to each candidate in this round
 }
 
 func (entry *LogEntry) VotesOf(i int) float64 {

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -34,6 +34,15 @@ func (l *Log) Winners() []int {
 	return out
 }
 
+func nameByIndex(snapshot []Candidate, idx int) string {
+	for i := range snapshot {
+		if snapshot[i].Index == idx {
+			return snapshot[i].Name
+		}
+	}
+	return fmt.Sprintf("candidate#%d", idx)
+}
+
 func (l *Log) Print() {
 	for _, e := range l.entries {
 		fmt.Println("round", e.Round)
@@ -51,7 +60,7 @@ func (l *Log) Print() {
 		if len(e.SurplusReceived) > 0 {
 			fmt.Println("surplus transfers:")
 			for idx, amt := range e.SurplusReceived {
-				name := e.CandidateSnapshot[idx].Name
+				name := nameByIndex(e.CandidateSnapshot, idx)
 				fmt.Printf("  -> %s: %.02f\n", name, amt)
 			}
 			if e.SurplusExhaustedDelta > 0 {
@@ -61,7 +70,7 @@ func (l *Log) Print() {
 		if len(e.EliminationReceived) > 0 {
 			fmt.Println("elimination transfers:")
 			for idx, amt := range e.EliminationReceived {
-				name := e.CandidateSnapshot[idx].Name
+				name := nameByIndex(e.CandidateSnapshot, idx)
 				fmt.Printf("  -> %s: %.02f\n", name, amt)
 			}
 			if e.EliminationExhaustedDelta > 0 {
@@ -97,7 +106,7 @@ func (l *Log) PrintString() string {
 		if len(e.SurplusReceived) > 0 {
 			result.WriteString("surplus transfers:\n")
 			for idx, amt := range e.SurplusReceived {
-				name := e.CandidateSnapshot[idx].Name
+				name := nameByIndex(e.CandidateSnapshot, idx)
 				result.WriteString(fmt.Sprintf("  -> %s: %.02f\n", name, amt))
 			}
 			if e.SurplusExhaustedDelta > 0 {
@@ -107,7 +116,7 @@ func (l *Log) PrintString() string {
 		if len(e.EliminationReceived) > 0 {
 			result.WriteString("elimination transfers:\n")
 			for idx, amt := range e.EliminationReceived {
-				name := e.CandidateSnapshot[idx].Name
+				name := nameByIndex(e.CandidateSnapshot, idx)
 				result.WriteString(fmt.Sprintf("  -> %s: %.02f\n", name, amt))
 			}
 			if e.EliminationExhaustedDelta > 0 {

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -46,7 +46,7 @@ func nameByIndex(snapshot []Candidate, idx int) string {
 func (l *Log) Print() {
 	for _, e := range l.entries {
 		fmt.Println("round", e.Round)
-		fmt.Printf("threshold %.02f (%.02f)\n", e.Threshold, e.Threshold/e.TotVotes*100)
+		fmt.Printf("threshold %.02f (%.02f%%)\n", e.Threshold, e.Threshold/e.TotVotes*100)
 		fmt.Printf("exhausted: %.02f\n", e.Exhausted)
 
 		// print the candidate votes in a table containing the name, keep factor and votes

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -103,9 +103,8 @@ type LogEntry struct {
 	Elected                    []Candidate
 	Defeated                   []Candidate
 	Exhausted                  float64
-	TransferredSurplus         float64         // votes transferred from surplus
-	TransferredFromElimination float64         // votes transferred from eliminated candidates
-	TransferredVotes           map[int]float64 // votes transferred to each candidate in this round
+	TransferredSurplus         float64 // votes transferred from surplus
+	TransferredFromElimination float64 // votes transferred from eliminated candidates
 }
 
 func (entry *LogEntry) VotesOf(i int) float64 {

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -38,8 +38,6 @@ func (l *Log) Print() {
 	for _, e := range l.entries {
 		fmt.Println("round", e.Round)
 		fmt.Printf("threshold %.02f (%.02f)\n", e.Threshold, e.Threshold/e.TotVotes*100)
-		fmt.Printf("transferred surplus: %.02f\n", e.TransferredSurplus)
-		fmt.Printf("transferred from elimination: %.02f\n", e.TransferredFromElimination)
 		fmt.Printf("exhausted: %.02f\n", e.Exhausted)
 
 		// print the candidate votes in a table containing the name, keep factor and votes
@@ -47,6 +45,28 @@ func (l *Log) Print() {
 		fmt.Println("candidate\tkeep\tvotes")
 		for _, c := range e.CandidateSnapshot {
 			fmt.Printf("%s\t%.02f\t%.02f\n", c.Name, c.KeepFactor, c.Votes)
+		}
+
+		// Print transfer breakdowns, if any
+		if len(e.SurplusReceived) > 0 {
+			fmt.Println("surplus transfers:")
+			for idx, amt := range e.SurplusReceived {
+				name := e.CandidateSnapshot[idx].Name
+				fmt.Printf("  -> %s: %.02f\n", name, amt)
+			}
+			if e.SurplusExhaustedDelta > 0 {
+				fmt.Printf("  -> exhausted: %.02f\n", e.SurplusExhaustedDelta)
+			}
+		}
+		if len(e.EliminationReceived) > 0 {
+			fmt.Println("elimination transfers:")
+			for idx, amt := range e.EliminationReceived {
+				name := e.CandidateSnapshot[idx].Name
+				fmt.Printf("  -> %s: %.02f\n", name, amt)
+			}
+			if e.EliminationExhaustedDelta > 0 {
+				fmt.Printf("  -> exhausted: %.02f\n", e.EliminationExhaustedDelta)
+			}
 		}
 
 		for _, elected := range e.Elected {
@@ -65,14 +85,34 @@ func (l *Log) PrintString() string {
 	for _, e := range l.entries {
 		result.WriteString(fmt.Sprintf("Round %d:\n", e.Round))
 		result.WriteString(fmt.Sprintf("Threshold: %.02f (%.02f%%)\n", e.Threshold, e.Threshold/e.TotVotes*100))
-		result.WriteString(fmt.Sprintf("Transferred surplus: %.02f\n", e.TransferredSurplus))
-		result.WriteString(fmt.Sprintf("Transferred from elimination: %.02f\n", e.TransferredFromElimination))
 		result.WriteString(fmt.Sprintf("Exhausted: %.02f\n", e.Exhausted))
 
 		// print the candidate votes in a table containing the name, keep factor and votes
 		result.WriteString("candidate\tkeep\tvotes\n")
 		for _, c := range e.CandidateSnapshot {
 			result.WriteString(fmt.Sprintf("%s\t%.02f\t%.02f\n", c.Name, c.KeepFactor, c.Votes))
+		}
+
+		// transfer breakdowns
+		if len(e.SurplusReceived) > 0 {
+			result.WriteString("surplus transfers:\n")
+			for idx, amt := range e.SurplusReceived {
+				name := e.CandidateSnapshot[idx].Name
+				result.WriteString(fmt.Sprintf("  -> %s: %.02f\n", name, amt))
+			}
+			if e.SurplusExhaustedDelta > 0 {
+				result.WriteString(fmt.Sprintf("  -> exhausted: %.02f\n", e.SurplusExhaustedDelta))
+			}
+		}
+		if len(e.EliminationReceived) > 0 {
+			result.WriteString("elimination transfers:\n")
+			for idx, amt := range e.EliminationReceived {
+				name := e.CandidateSnapshot[idx].Name
+				result.WriteString(fmt.Sprintf("  -> %s: %.02f\n", name, amt))
+			}
+			if e.EliminationExhaustedDelta > 0 {
+				result.WriteString(fmt.Sprintf("  -> exhausted: %.02f\n", e.EliminationExhaustedDelta))
+			}
 		}
 
 		for _, elected := range e.Elected {
@@ -96,15 +136,22 @@ func (l *Log) last() *LogEntry {
 }
 
 type LogEntry struct {
-	Round                      int
-	Threshold                  float64
-	TotVotes                   float64
-	CandidateSnapshot          []Candidate
-	Elected                    []Candidate
-	Defeated                   []Candidate
-	Exhausted                  float64
-	TransferredSurplus         float64 // votes transferred from surplus
-	TransferredFromElimination float64 // votes transferred from eliminated candidates
+	Round             int
+	Threshold         float64
+	TotVotes          float64
+	CandidateSnapshot []Candidate
+	Elected           []Candidate
+	Defeated          []Candidate
+	Exhausted         float64
+
+	// Transfer breakdowns realized in this round compared to previous round's event
+	// If the previous round elected candidate(s), SurplusReceived shows how much each candidate gained
+	// due to surplus redistribution. If the previous round eliminated a candidate, EliminationReceived
+	// shows how much each candidate gained from that elimination.
+	SurplusReceived           map[int]float64
+	EliminationReceived       map[int]float64
+	SurplusExhaustedDelta     float64
+	EliminationExhaustedDelta float64
 }
 
 func (entry *LogEntry) VotesOf(i int) float64 {

--- a/meekstv/report.go
+++ b/meekstv/report.go
@@ -42,7 +42,7 @@ func (l *Log) Print() {
 		fmt.Printf("transferred from elimination: %.02f\n", e.TransferredFromElimination)
 		fmt.Printf("exhausted: %.02f\n", e.Exhausted)
 
-		// print the candidate votes in a table containing the name, keep factor, votes, and state
+		// print the candidate votes in a table containing the name, keep factor and votes
 		// for every round
 		fmt.Println("candidate\tkeep\tvotes")
 		for _, c := range e.CandidateSnapshot {
@@ -69,7 +69,7 @@ func (l *Log) PrintString() string {
 		result.WriteString(fmt.Sprintf("Transferred from elimination: %.02f\n", e.TransferredFromElimination))
 		result.WriteString(fmt.Sprintf("Exhausted: %.02f\n", e.Exhausted))
 
-		// print the candidate votes in a table containing the name, keep factor, votes, and state
+		// print the candidate votes in a table containing the name, keep factor and votes
 		result.WriteString("candidate\tkeep\tvotes\n")
 		for _, c := range e.CandidateSnapshot {
 			result.WriteString(fmt.Sprintf("%s\t%.02f\t%.02f\n", c.Name, c.KeepFactor, c.Votes))

--- a/meekstv/transfers_test.go
+++ b/meekstv/transfers_test.go
@@ -1,0 +1,153 @@
+package meekstv
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/linuxfoundation-it/meek-stv/election"
+)
+
+type expectedJSON struct {
+	Winners []int  `json:"winners"`
+	Title   string `json:"title"`
+}
+
+func readJSONExpect(t *testing.T, jsonPath string) expectedJSON {
+	t.Helper()
+	f, err := os.Open(jsonPath)
+	if err != nil {
+		t.Fatalf("open json: %v", err)
+	}
+	defer f.Close()
+	var exp expectedJSON
+	if err := json.NewDecoder(f).Decode(&exp); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	return exp
+}
+
+func readElectionTxt(t *testing.T, txtPath string) *election.Election {
+	t.Helper()
+	f, err := os.Open(txtPath)
+	if err != nil {
+		t.Fatalf("open txt: %v", err)
+	}
+	defer f.Close()
+	return election.Read(f)
+}
+
+func floatAlmostEqual(a, b, tol float64) bool {
+	return math.Abs(a-b) <= tol
+}
+
+func asSortedCopy(ints []int) []int {
+	out := append([]int(nil), ints...)
+	sort.Ints(out)
+	return out
+}
+
+func TestElection10_WinnersAndTransfers(t *testing.T) {
+	base := filepath.Join("..", "testdata")
+	txt := filepath.Join(base, "election10.txt")
+	jsonPath := filepath.Join(base, "election10.json")
+
+	params := readElectionTxt(t, txt)
+	report := Count(params)
+
+	exp := readJSONExpect(t, jsonPath)
+
+	// winners match
+	gotWinners := report.Winners()
+	if !slicesEqual(asSortedCopy(gotWinners), asSortedCopy(exp.Winners)) {
+		t.Fatalf("winners mismatch: got %v, want %v", gotWinners, exp.Winners)
+	}
+
+	// transfer conservation per round
+	checkTransferConservation(t, &report)
+}
+
+func TestElection11_WinnersAndTransfers(t *testing.T) {
+	base := filepath.Join("..", "testdata")
+	txt := filepath.Join(base, "election11.txt")
+	jsonPath := filepath.Join(base, "election11.json")
+
+	params := readElectionTxt(t, txt)
+	report := Count(params)
+
+	exp := readJSONExpect(t, jsonPath)
+
+	// winners match
+	gotWinners := report.Winners()
+	if !slicesEqual(asSortedCopy(gotWinners), asSortedCopy(exp.Winners)) {
+		t.Fatalf("winners mismatch: got %v, want %v", gotWinners, exp.Winners)
+	}
+
+	// transfer conservation per round
+	checkTransferConservation(t, &report)
+}
+
+func checkTransferConservation(t *testing.T, report *Log) {
+	t.Helper()
+	entries := report.entries
+	if len(entries) < 2 {
+		return
+	}
+	const tol = 1e-2
+	for i := 1; i < len(entries); i++ {
+		prev := entries[i-1]
+		cur := entries[i]
+		// If previous round eliminated someone, positive deltas + exhausted delta should equal eliminated candidate's prior votes
+		if len(prev.Defeated) > 0 {
+			defeatedIdx := prev.Defeated[0].Index
+			defeatedVotes := prev.CandidateSnapshot[defeatedIdx].Votes
+			sumRecipients := 0.0
+			for _, v := range cur.EliminationReceived {
+				sumRecipients += v
+			}
+			total := sumRecipients + cur.EliminationExhaustedDelta
+			if !floatAlmostEqual(total, defeatedVotes, tol) {
+				t.Fatalf("round %d elimination conservation failed: got %.2f (recipients %.2f + exhausted %.2f), want %.2f", cur.Round, total, sumRecipients, cur.EliminationExhaustedDelta, defeatedVotes)
+			}
+		}
+		// If previous round elected someone, positive deltas + exhausted delta should equal the actual drop in elected candidates' votes between rounds
+		if len(prev.Elected) > 0 {
+			// compute total drop among candidates who were elected in prev round
+			prevSnap := prev.CandidateSnapshot
+			curSnap := cur.CandidateSnapshot
+			totalDrop := 0.0
+			for _, ec := range prev.Elected {
+				idx := ec.Index
+				if idx >= 0 && idx < len(prevSnap) && idx < len(curSnap) {
+					delta := prevSnap[idx].Votes - curSnap[idx].Votes
+					if delta > 0 {
+						totalDrop += delta
+					}
+				}
+			}
+			sumRecipients := 0.0
+			for _, v := range cur.SurplusReceived {
+				sumRecipients += v
+			}
+			total := sumRecipients + cur.SurplusExhaustedDelta
+			if !floatAlmostEqual(total, totalDrop, tol) {
+				t.Fatalf("round %d surplus conservation failed: got %.2f (recipients %.2f + exhausted %.2f), want %.2f (drop in elected)", cur.Round, total, sumRecipients, cur.SurplusExhaustedDelta, totalDrop)
+			}
+		}
+	}
+}
+
+func slicesEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Issue: PCC-420

This pull request introduces detailed tracking and reporting of vote transfers between candidates during surplus redistributions and eliminations in Meek STV elections. It adds new fields to the reporting structures, updates output methods to display transfer breakdowns, and provides comprehensive tests to verify transfer conservation and correctness. A custom case and related test are also included for targeted validation.

Example Round Summary output

```
Round 0:
Threshold: 3.00 (33.33%)
Exhausted: 0.00
candidate       keep    votes
1e6ce7e3-e957-4749-8679-8b2a86751da1    1.00    2.00
2faad174-ea38-47e0-aa47-e0b4b3e146bb    0.75    4.00
468db457-cdee-483c-8182-ad260547524b    1.00    2.00
69399f1d-ee87-496f-ac73-4990af6f91b7    1.00    0.00
6a90af0c-e2bd-48b6-882a-445122e46532    1.00    0.00
7d72a470-19f5-4bea-9c47-6de52b18bf8f    1.00    1.00
Elected: 2faad174-ea38-47e0-aa47-e0b4b3e146bb with 4.00 votes
-------------------------
Round 1:
Threshold: 3.00 (33.33%)
Exhausted: 0.00
candidate       keep    votes
1e6ce7e3-e957-4749-8679-8b2a86751da1    1.00    2.00
2faad174-ea38-47e0-aa47-e0b4b3e146bb    0.75    3.00
468db457-cdee-483c-8182-ad260547524b    1.00    2.75
69399f1d-ee87-496f-ac73-4990af6f91b7    1.00    0.25
6a90af0c-e2bd-48b6-882a-445122e46532    1.00    0.00
7d72a470-19f5-4bea-9c47-6de52b18bf8f    1.00    1.00
surplus transfers:
  -> 468db457-cdee-483c-8182-ad260547524b: 0.75
  -> 69399f1d-ee87-496f-ac73-4990af6f91b7: 0.25
Eliminated: 6a90af0c-e2bd-48b6-882a-445122e46532
-------------------------
Round 2:
Threshold: 3.00 (33.33%)
Exhausted: 0.00
candidate       keep    votes
1e6ce7e3-e957-4749-8679-8b2a86751da1    1.00    2.00
2faad174-ea38-47e0-aa47-e0b4b3e146bb    0.75    3.00
468db457-cdee-483c-8182-ad260547524b    1.00    2.75
69399f1d-ee87-496f-ac73-4990af6f91b7    1.00    0.25
6a90af0c-e2bd-48b6-882a-445122e46532    0.00    0.00
7d72a470-19f5-4bea-9c47-6de52b18bf8f    1.00    1.00
Eliminated: 69399f1d-ee87-496f-ac73-4990af6f91b7
-------------------------
Round 3:
Threshold: 3.00 (33.33%)
Exhausted: 0.00
candidate       keep    votes
1e6ce7e3-e957-4749-8679-8b2a86751da1    1.00    2.00
2faad174-ea38-47e0-aa47-e0b4b3e146bb    0.75    3.00
468db457-cdee-483c-8182-ad260547524b    1.00    2.75
69399f1d-ee87-496f-ac73-4990af6f91b7    0.00    0.00
6a90af0c-e2bd-48b6-882a-445122e46532    0.00    0.00
7d72a470-19f5-4bea-9c47-6de52b18bf8f    1.00    1.25
elimination transfers:
  -> 7d72a470-19f5-4bea-9c47-6de52b18bf8f: 0.25
Eliminated: 7d72a470-19f5-4bea-9c47-6de52b18bf8f
-------------------------
Round 4:
Threshold: 3.00 (33.33%)
Exhausted: 0.00
candidate       keep    votes
1e6ce7e3-e957-4749-8679-8b2a86751da1    1.00    2.25
2faad174-ea38-47e0-aa47-e0b4b3e146bb    0.75    3.00
468db457-cdee-483c-8182-ad260547524b    0.80    3.75
69399f1d-ee87-496f-ac73-4990af6f91b7    0.00    0.00
6a90af0c-e2bd-48b6-882a-445122e46532    0.00    0.00
7d72a470-19f5-4bea-9c47-6de52b18bf8f    0.00    0.00
elimination transfers:
  -> 1e6ce7e3-e957-4749-8679-8b2a86751da1: 0.25
  -> 468db457-cdee-483c-8182-ad260547524b: 1.00
Elected: 468db457-cdee-483c-8182-ad260547524b with 3.75 votes
-------------------------
```

**Enhancements to transfer tracking and reporting:**

* Added new fields (`SurplusReceived`, `EliminationReceived`, and their exhausted deltas) to the `LogEntry` struct to capture detailed per-candidate vote gains from surplus and elimination events.
* Updated the `run` method in `meekstv.go` to compute these transfer breakdowns after each round, attributing positive vote deltas to candidates based on surplus distribution or elimination, and tracking exhausted votes.
* Enhanced the `Print` and `PrintString` methods in `report.go` to display the new transfer breakdowns in the round-by-round output, including candidate names and exhausted vote changes. [[1]](diffhunk://#diff-88ef9998c764097219742be3221199df97960c9c9a36cd8f579ab9d4bd7b90cdR37-R79) [[2]](diffhunk://#diff-88ef9998c764097219742be3221199df97960c9c9a36cd8f579ab9d4bd7b90cdR97-R125)

**Testing and validation:**

* Added `transfers_test.go` with tests for transfer conservation and correctness using real election data, ensuring that all transferred votes are properly accounted for in both surplus and elimination scenarios.
* Introduced a custom case in `custom_case_test.go` to verify elimination recipient calculations in a controlled scenario.

**Utilities and examples:**

* Added a standalone example program in `cmd/customcase/main.go` to demonstrate and debug the transfer reporting on a specific election case.

These changes improve the transparency and auditability of the Meek STV implementation by making vote transfers explicit and testable.