### PR TITLE
[PCC-792] fix panic when there are no entries

### DIFF
--- a/cmd/twoseats/main.go
+++ b/cmd/twoseats/main.go
@@ -19,6 +19,12 @@ func main() {
 	runScenario([]election.Ballot{
 		{Weight: 1, Preferences: []int{0, 1}},
 	})
+
+	fmt.Println("\n== Scenario C: two ballots both selecting the same choice ==")
+	runScenario([]election.Ballot{
+		{Weight: 1, Preferences: []int{0, 1}},
+		{Weight: 1, Preferences: []int{0, 1}},
+	})
 }
 
 func runScenario(ballots []election.Ballot) {
@@ -65,11 +71,9 @@ func runScenario(ballots []election.Ballot) {
 	cands := append([]meekstv.Candidate(nil), report.Results()...)
 	sort.Slice(cands, func(i, j int) bool { return cands[i].Votes > cands[j].Votes })
 	fmt.Println("Winners:")
-	count := 0
 	for _, c := range cands {
 		if c.State == meekstv.Elected {
 			fmt.Printf("- %s (%.2f)\n", c.Name, c.Votes)
-			count++
 		}
 	}
 }

--- a/cmd/twoseats/main.go
+++ b/cmd/twoseats/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/linuxfoundation-it/meek-stv/election"
+	"github.com/linuxfoundation-it/meek-stv/meekstv"
+)
+
+func main() {
+	fmt.Println("== Scenario A: two ballots (one for each choice) ==")
+	runScenario([]election.Ballot{
+		{Weight: 1, Preferences: []int{0}},
+		{Weight: 1, Preferences: []int{1}},
+	})
+
+	fmt.Println("\n== Scenario B: single ballot ranking both choices ==")
+	runScenario([]election.Ballot{
+		{Weight: 1, Preferences: []int{0, 1}},
+	})
+}
+
+func runScenario(ballots []election.Ballot) {
+	choices := []string{
+		"choice-A", // idx 0
+		"choice-B", // idx 1
+	}
+
+	params := &election.Election{
+		Title:          "TwoSeats",
+		Candidates:     len(choices),
+		Seats:          2,
+		Withdrawn:      map[int]bool{},
+		Ballots:        ballots,
+		CandidateNames: choices,
+	}
+
+	report := meekstv.Count(params)
+
+	if report.NumRounds() == 0 {
+		fmt.Println("no rounds logged")
+		return
+	}
+
+	for i := 0; i < report.NumRounds(); i++ {
+		e := report.Round(i)
+		fmt.Printf("Round %d:\n", e.Round)
+		fmt.Printf("Threshold: %.2f (%.2f%%)\n", e.Threshold, safePct(e.Threshold, e.TotVotes))
+		fmt.Printf("Exhausted: %.2f\n", e.Exhausted)
+		fmt.Println("candidate\tkeep\tvotes")
+		for _, c := range e.CandidateSnapshot {
+			fmt.Printf("%s\t%.2f\t%.2f\n", c.Name, c.KeepFactor, c.Votes)
+		}
+		for _, elected := range e.Elected {
+			fmt.Printf("Elected: %s with %.2f votes\n", elected.Name, elected.Votes)
+		}
+		for _, defeated := range e.Defeated {
+			fmt.Printf("Eliminated: %s\n", defeated.Name)
+		}
+		fmt.Println("-------------------------")
+	}
+
+	// Final winners summary to verify both are elected
+	cands := append([]meekstv.Candidate(nil), report.Results()...)
+	sort.Slice(cands, func(i, j int) bool { return cands[i].Votes > cands[j].Votes })
+	fmt.Println("Winners:")
+	count := 0
+	for _, c := range cands {
+		if c.State == meekstv.Elected {
+			fmt.Printf("- %s (%.2f)\n", c.Name, c.Votes)
+			count++
+		}
+	}
+}
+
+func safePct(x, total float64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return (x / total) * 100
+}

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -45,6 +45,10 @@ func Count(params *election.Election) Log {
 		elected := cs.countState(Elected)
 		if elected >= params.Seats || elected+hopeful <= params.Seats {
 			round.complete(params.Seats)
+			// Ensure there is a round entry before accessing the last log entry
+			if round.report.NumRounds() == 0 {
+				round.report.add(round.n)
+			}
 			// Make sure to log the last round snapshot before returning
 			// Found edge case where the last round was not being logged when a hopeful candidate was elected
 			roundLog := round.report.last()

--- a/meekstv/meekstv.go
+++ b/meekstv/meekstv.go
@@ -44,11 +44,13 @@ func Count(params *election.Election) Log {
 		hopeful := cs.countState(Hopeful)
 		elected := cs.countState(Elected)
 		if elected >= params.Seats || elected+hopeful <= params.Seats {
-			round.complete(params.Seats)
 			// Ensure there is a round entry before accessing the last log entry
 			if round.report.NumRounds() == 0 {
 				round.report.add(round.n)
+				round.run(params)
 			}
+			round.complete(params.Seats)
+
 			// Make sure to log the last round snapshot before returning
 			// Found edge case where the last round was not being logged when a hopeful candidate was elected
 			roundLog := round.report.last()


### PR DESCRIPTION
Issue: PCC-792

This pull request introduces a new example scenario for the Meek STV election algorithm and fixes an edge case in the round logging logic. The main changes include adding a new demonstration command-line utility and improving the reliability of the round logging in the counting function.

### New example scenario and demonstration utility

* Added a new command-line utility `cmd/twoseats/main.go` that demonstrates two Meek STV election scenarios: one with two ballots (one for each candidate) and another with a single ballot ranking both candidates. This helps verify that both candidates are elected when there are two seats and two candidates.

### Reliability improvements in round logging

* Fixed an edge case in `meekstv/meekstv.go` where the last round was not being logged if a hopeful candidate was elected. Now, the code ensures there is a round entry before accessing the last log entry, improving the accuracy of the election report.